### PR TITLE
Remove prop year from Grid widget

### DIFF
--- a/lib/controllers/gridController.dart
+++ b/lib/controllers/gridController.dart
@@ -13,11 +13,7 @@ class GridController extends ChangeNotifier {
     days = [];
     _dayBoxDAO = DayBoxDAO();
     _dayBoxDAO.getAllDays(year).then((daysList) {
-      if (daysList.isEmpty) {
-        _dayBoxDAO.createAllDays(year).then((newList) => updateDays(newList));
-      } else {
-        updateDays(daysList);
-      }
+      updateDays(daysList);
     });
   }
 

--- a/lib/controllers/gridController.dart
+++ b/lib/controllers/gridController.dart
@@ -26,7 +26,7 @@ class GridController extends ChangeNotifier {
     return days[index].feeling;
   }
 
-  DateTime getDayDate(int index) {
+  DayBoxDate getDayDate(int index) {
     return days[index].date;
   }
 

--- a/lib/data/dayBoxDAO.dart
+++ b/lib/data/dayBoxDAO.dart
@@ -42,11 +42,16 @@ class DayBoxDAO {
       finder: finder,
     );
 
-    return recordSnapshots.map((snapshot) {
+    List<DayBoxModel> daysList = recordSnapshots.map((snapshot) {
       final dayBox = DayBoxModel.fromMap(snapshot.value);
       dayBox.id = snapshot.key;
       return dayBox;
     }).toList();
+
+    if (daysList.isEmpty) {
+      daysList = await createAllDays(year);
+    }
+    return daysList;
   }
 
   static Random random = new Random();
@@ -57,8 +62,7 @@ class DayBoxDAO {
     for (int month = 1; month <= 12; month++) {
       for (int day = 1; day <= numberOfDaysPerMonth[month - 1]; day++) {
         await insert(DayBoxModel(
-            date: DateTime.utc(year, month, day),
-            feeling: FeelingModel.getAllFeelings()[random.nextInt(6)]));
+            date: DateTime.utc(year, month, day), feeling: FeelingModel()));
       }
     }
 

--- a/lib/data/dayBoxDAO.dart
+++ b/lib/data/dayBoxDAO.dart
@@ -62,7 +62,10 @@ class DayBoxDAO {
     for (int month = 1; month <= 12; month++) {
       for (int day = 1; day <= numberOfDaysPerMonth[month - 1]; day++) {
         await insert(DayBoxModel(
-            date: DateTime.utc(year, month, day), feeling: FeelingModel()));
+            date: DateTime.utc(year, month, day),
+            feeling: FeelingModel(
+                color: FeelingModel.colors[0],
+                description: FeelingModel.descriptions[0])));
       }
     }
 

--- a/lib/data/dayBoxDAO.dart
+++ b/lib/data/dayBoxDAO.dart
@@ -54,15 +54,13 @@ class DayBoxDAO {
     return daysList;
   }
 
-  static Random random = new Random();
-
   Future<List<DayBoxModel>> createAllDays(int year) async {
     List<int> numberOfDaysPerMonth = getAllNumberOfDaysPerMonth(year);
 
     for (int month = 1; month <= 12; month++) {
       for (int day = 1; day <= numberOfDaysPerMonth[month - 1]; day++) {
         await insert(DayBoxModel(
-            date: DateTime.utc(year, month, day),
+            date: DayBoxDate(day: day, month: month, year: year),
             feeling: FeelingModel(
                 color: FeelingModel.colors[0],
                 description: FeelingModel.descriptions[0])));

--- a/lib/data/feelingsCollectionDAO.dart
+++ b/lib/data/feelingsCollectionDAO.dart
@@ -47,7 +47,8 @@ class FeelingsDAO {
   static Random random = new Random();
 
   Future<FeelingsCollectionModel> createDefaultCollection(int year) async {
-    List<Color> colors = [
+    List colors = [
+      Colors.white,
       Colors.pink,
       Colors.black,
       Colors.blue,
@@ -57,6 +58,7 @@ class FeelingsDAO {
     ];
 
     List<String> descriptions = [
+      "",
       "Marvelous",
       "Very Sad",
       "Normal",
@@ -66,7 +68,7 @@ class FeelingsDAO {
     ];
 
     List<FeelingModel> feelings = List<FeelingModel>();
-    for (int i = 0; i < 6; i++) {
+    for (int i = 0; i < 7; i++) {
       feelings
           .add(FeelingModel(color: colors[i], description: descriptions[i]));
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,7 +24,7 @@ class MyApp extends StatelessWidget {
         appBar: AppBar(
           title: Text('Year in Pixels'),
         ),
-        body: Grid(year: 2020),
+        body: Grid(),
       ),
     );
   }

--- a/lib/models/dayBoxModel.dart
+++ b/lib/models/dayBoxModel.dart
@@ -1,27 +1,35 @@
+import 'dart:ffi';
+
 import 'package:sembast/timestamp.dart';
 
 import 'feelingModel.dart';
 
+class DayBoxDate {
+  int day, month, year;
+  DayBoxDate({this.day, this.month, this.year});
+}
+
 class DayBoxModel {
   FeelingModel feeling;
-  DateTime date;
-  int id, year;
+  DayBoxDate date;
 
-  DayBoxModel({this.date, this.feeling}) : year = date.year;
+  int id;
 
-  // We are converting from DateTime to Timestamp
-  // because Sembast doesn't accept DateTime type
+  DayBoxModel({this.date, this.feeling});
+
   Map<String, dynamic> toMap() {
     return {
-      'date': Timestamp.fromDateTime(date),
-      'year': year,
+      'day': date.day,
+      'month': date.month,
+      'year': date.year,
       'feeling': feeling.toMap()
     };
   }
 
   static DayBoxModel fromMap(Map<String, dynamic> map) {
     return DayBoxModel(
-        date: map['date'].toDateTime(),
+        date:
+            DayBoxDate(day: map['day'], month: map['month'], year: map['year']),
         feeling: FeelingModel.fromMap(map['feeling']));
   }
 

--- a/lib/models/feelingModel.dart
+++ b/lib/models/feelingModel.dart
@@ -7,6 +7,7 @@ class FeelingModel {
   FeelingModel({this.color, this.description});
 
   static List colors = [
+    Colors.white,
     Colors.pink,
     Colors.black,
     Colors.blue,
@@ -16,6 +17,7 @@ class FeelingModel {
   ];
 
   static List<String> descriptions = [
+    "",
     "Marvelous",
     "Very Sad",
     "Normal",
@@ -25,8 +27,8 @@ class FeelingModel {
   ];
 
   static List<FeelingModel> getAllFeelings() {
-    List<FeelingModel> feelings = List<FeelingModel>();
-    for (int i = 0; i < 6; i++) {
+    List<FeelingModel> feelings = [];
+    for (int i = 1; i < 7; i++) {
       feelings
           .add(FeelingModel(color: colors[i], description: descriptions[i]));
     }

--- a/lib/models/feelingModel.dart
+++ b/lib/models/feelingModel.dart
@@ -28,7 +28,7 @@ class FeelingModel {
 
   static List<FeelingModel> getAllFeelings() {
     List<FeelingModel> feelings = [];
-    for (int i = 1; i < 7; i++) {
+    for (int i = 0; i < 7; i++) {
       feelings
           .add(FeelingModel(color: colors[i], description: descriptions[i]));
     }

--- a/lib/widgets/daybox.dart
+++ b/lib/widgets/daybox.dart
@@ -2,12 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:year_in_pixels/controllers/gridController.dart';
 import 'package:year_in_pixels/helpers/util.dart';
+import 'package:year_in_pixels/models/dayBoxModel.dart';
 import 'package:year_in_pixels/models/feelingModel.dart';
 import 'package:year_in_pixels/widgets/modalUpdateDay.dart';
 
 class DayBoxState extends State<DayBox> {
   Color _color;
-  DateTime _date;
+  DayBoxDate _date;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/daybox.dart
+++ b/lib/widgets/daybox.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:year_in_pixels/controllers/gridController.dart';
-import 'package:year_in_pixels/helpers/constants.dart';
 import 'package:year_in_pixels/helpers/util.dart';
 import 'package:year_in_pixels/models/feelingModel.dart';
 import 'package:year_in_pixels/widgets/modalUpdateDay.dart';

--- a/lib/widgets/grid.dart
+++ b/lib/widgets/grid.dart
@@ -7,9 +7,7 @@ import 'package:year_in_pixels/helpers/util.dart';
 import 'package:year_in_pixels/widgets/daybox.dart';
 
 class Grid extends StatelessWidget {
-  final int year;
-
-  Grid({Key key, this.year}) : super(key: key);
+  Grid({Key key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -17,28 +15,29 @@ class Grid extends StatelessWidget {
     queryData = MediaQuery.of(context);
     double boxsize = (queryData.size.width / 12.0);
 
-    List<int> numberOfDaysPerMonth = getAllNumberOfDaysPerMonth(year);
-    List<List<int>> monthsListOfDaysIndexes = List<List<int>>();
-
-    int index = 0;
-    numberOfDaysPerMonth.forEach((numberOfDays) {
-      List<int> daysIndexes = List<int>();
-      for (int i = 0; i < numberOfDays; i++) {
-        daysIndexes.add(index);
-        index++;
-      }
-      monthsListOfDaysIndexes.add(daysIndexes);
-    });
-
-    List<Month> allMonths = monthsListOfDaysIndexes
-        .map((daysIndexes) => Month(days: daysIndexes, boxsize: boxsize))
-        .toList();
-
     return Consumer2<GridController, FeelingsController>(
         builder: (context, grid, feelingsController, child) {
       if (grid.days.isEmpty || feelingsController.feelingsCollection == null) {
         return Text("Loading...");
       }
+
+      List<int> numberOfDaysPerMonth = getAllNumberOfDaysPerMonth(grid.year);
+      List<List<int>> monthsListOfDaysIndexes = [];
+
+      int index = 0;
+      numberOfDaysPerMonth.forEach((numberOfDays) {
+        List<int> daysIndexes = [];
+        for (int i = 0; i < numberOfDays; i++) {
+          daysIndexes.add(index);
+          index++;
+        }
+        monthsListOfDaysIndexes.add(daysIndexes);
+      });
+
+      List<Month> allMonths = monthsListOfDaysIndexes
+          .map((daysIndexes) => Month(days: daysIndexes, boxsize: boxsize))
+          .toList();
+
       return ListView(
         children: <Widget>[
           MonthsDisplay(boxsize: boxsize),

--- a/lib/widgets/modalUpdateDay.dart
+++ b/lib/widgets/modalUpdateDay.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:year_in_pixels/controllers/feelingsController.dart';
+import 'package:year_in_pixels/models/dayBoxModel.dart';
 import 'package:year_in_pixels/models/feelingModel.dart';
 
 class ModalUpdateDayState extends State<ModalUpdateDay> {
@@ -10,10 +11,10 @@ class ModalUpdateDayState extends State<ModalUpdateDay> {
   FeelingModel _selected;
   Color _color;
 
-  ModalUpdateDayState(Color currentColor, DateTime date) {
+  ModalUpdateDayState(Color currentColor, DayBoxDate date) {
     _color = currentColor;
     DateFormat formatter = DateFormat('MMM d, y');
-    _date = formatter.format(date);
+    _date = formatter.format(DateTime(date.year, date.month, date.day));
   }
 
   Widget build(BuildContext context) {
@@ -32,6 +33,7 @@ class ModalUpdateDayState extends State<ModalUpdateDay> {
       content: Container(
         margin: EdgeInsets.symmetric(vertical: 20.0),
         height: 70.0,
+        width: 70.0,
         child: ListView.builder(
           scrollDirection: Axis.horizontal,
           itemCount: _feelings.length,
@@ -81,7 +83,7 @@ class ModalUpdateDayState extends State<ModalUpdateDay> {
 
 class ModalUpdateDay extends StatefulWidget {
   final Color currentColor;
-  final DateTime date;
+  final DayBoxDate date;
 
   ModalUpdateDay({Key key, this.currentColor, this.date}) : super(key: key);
 


### PR DESCRIPTION
## Context
The variable year from GridWidget was being initially set from main. However, at GridController, the initial year is the current year. Instead of having these two variables, GridWidget should get the year from the GridController as well.